### PR TITLE
Add set operations

### DIFF
--- a/core/ergodict.lisp
+++ b/core/ergodict.lisp
@@ -267,6 +267,12 @@
 
 (define-method (iterator (s set implementation)) (iterator implementation))
 
+(defmacro with-scollector (var &body body)
+  (with-gensyms (result item)
+    `(let ( (,result (make-set)) )
+       (flet ( (,var (,item) (add ,result ,item) ,item) )
+         ,@body)
+       ,result)))
 
 ;;;;;;;;;;;;;;;;;;;;;;
 ;;;

--- a/core/ergodict.lisp
+++ b/core/ergodict.lisp
@@ -277,6 +277,10 @@
          ,@body)
        ,result)))
 
+(defun sforce (iterator)
+  (with-scollector collect
+    (for item in iterator do (collect item))))
+
 ;;;;;;;;;;;;;;;;;;;;;;
 ;;;
 ;;; Binner

--- a/core/ergodict.lisp
+++ b/core/ergodict.lisp
@@ -263,6 +263,9 @@
 (define-method (intersection (s1 set) (s2 set))
   (make-set :items (for i in s1 if (member? s2 i) collect i)))
 
+(define-method (difference (s1 set) (s2 set))
+  (filter s1 (complement (fn (item) (member? s2 item)))))
+
 (define-method (members (s set)) (keys s))
 
 (define-method (iterator (s set implementation)) (iterator implementation))

--- a/core/ergodict.lisp
+++ b/core/ergodict.lisp
@@ -270,17 +270,6 @@
 
 (define-method (iterator (s set implementation)) (iterator implementation))
 
-(defmacro with-scollector (var &body body)
-  (with-gensyms (result item)
-    `(let ( (,result (make-set)) )
-       (flet ( (,var (,item) (add ,result ,item) ,item) )
-         ,@body)
-       ,result)))
-
-(defun sforce (iterator)
-  (with-scollector collect
-    (for item in iterator do (collect item))))
-
 ;;;;;;;;;;;;;;;;;;;;;;
 ;;;
 ;;; Binner

--- a/core/ergodict.lisp
+++ b/core/ergodict.lisp
@@ -241,6 +241,11 @@
 ;;;
 (define-class (set dictionary))
 
+(defun make-set (&key (implementation (make-hash-table)) (items nil))
+  (bb s (make-instance 'set :implementation implementation)
+      (for item in items do (add s item))
+      s))
+
 (define-method (member? (s set) item) (refd s item nil))
 
 (define-method (add (s set) item) (setf (ref s item) item) s)

--- a/core/ergoutils.lisp
+++ b/core/ergoutils.lisp
@@ -208,12 +208,6 @@
       (if (funcall function item)
         (collect item)))))
 
-(define-method (filter (s set) function)
-  (with-scollector collect
-    (for item in s do
-      (if (funcall function item)
-        (collect item)))))
-
 (define-method (filter (s string) function)
   (with-char-collector collect
     (for c in s do

--- a/core/ergoutils.lisp
+++ b/core/ergoutils.lisp
@@ -208,6 +208,12 @@
       (if (funcall function item)
         (collect item)))))
 
+(define-method (filter (s set) function)
+  (with-scollector collect
+    (for item in s do
+      (if (funcall function item)
+        (collect item)))))
+
 (define-method (filter (s string) function)
   (with-char-collector collect
     (for c in s do

--- a/core/iterators.lisp
+++ b/core/iterators.lisp
@@ -201,6 +201,10 @@
     (for item in iterator do (collect item))))
 
 (defun sforce (iterator)
+  (with-scollector collect
+    (for item in iterator do (collect item))))
+
+(defun strforce (iterator)
   (with-char-collector collect
     (for item in iterator do (collect item))))
 

--- a/core/iterators.lisp
+++ b/core/iterators.lisp
@@ -52,13 +52,13 @@
   (check-keyword in :in)
   (bb kw (1st body)
       (if (consp kw) (setf kw :do) (pop body))
-      (check-keyword kw '(:do :if :collect :vcollect :scollect :yield) 'error)
+      (check-keyword kw '(:do :if :collect :vcollect :yield) 'error)
       condition t
       (mcond (id= kw :if)
              (setf condition (1st body) kw (2nd body) body (rrst body))
              (and (= (length body) 3) (id= (2nd body) :if))
              (setf condition (3rd body) body (list (1st body))))
-      (check-keyword kw '(:do :collect :vcollect :scollect :yield) 'error)
+      (check-keyword kw '(:do :collect :vcollect :yield) 'error)
       (if (and (cddr body) (not (id= kw :do)))
         (error "Multiple forms following a ~A keyword" kw))
       (push 'progn body)
@@ -71,9 +71,6 @@
                        (iterdo ,var ,thing (if ,condition (,collect ,body))))))
         (:vcollect (with-gensym collect
                      `(with-vcollector ,collect
-                        (iterdo ,var ,thing (if ,condition (,collect ,body))))))
-        (:scollect (with-gensym collect
-                     `(with-scollector ,collect
                         (iterdo ,var ,thing (if ,condition (,collect ,body)))))))))
 
 (defmacro collect (expr for var in iter &optional if condition)
@@ -89,13 +86,6 @@
   (if if
     `(for ,var in ,iter vcollect ,expr ,if ,condition)
     `(for ,var in ,iter vcollect ,expr)))
-
-(defmacro scollect (expr for var in iter &optional if condition)
-  (check-keyword for :for 'error)
-  (check-keyword in :in 'error)
-  (if if
-    `(for ,var in ,iter scollect ,expr ,if ,condition)
-    `(for ,var in ,iter scollect ,expr)))
 
 (define-method (iterator (l list)) (fn () (if l (pop l) (iterend))))
 
@@ -200,7 +190,7 @@
   (with-vcollector collect
     (for item in iterator do (collect item))))
 
-(defun strforce (iterator)
+(defun sforce (iterator)
   (with-char-collector collect
     (for item in iterator do (collect item))))
 

--- a/core/iterators.lisp
+++ b/core/iterators.lisp
@@ -73,6 +73,45 @@
                      `(with-vcollector ,collect
                         (iterdo ,var ,thing (if ,condition (,collect ,body)))))))))
 
+(defun check-keyword-with-arrow (kw expected &optional (function 'warn))
+  (bb s (->string kw)
+      arrows '(-> -><type>)
+      (if (starts-with s "->")
+        (slice s 2)
+        (check-keyword kw (cat expected arrows) function))))
+
+;;; FOR with an arrow
+(defmacro forw (var in thing &body body)
+  (check-keyword in :in)
+  (bb kw (1st body)
+      (if (consp kw) (setf kw :do) (pop body))
+      (check-keyword-with-arrow kw '(:do :if :yield) 'error)
+      condition t
+      (mcond (id= kw :if)
+             (setf condition (1st body) kw (2nd body) body (rrst body))
+             (and (= (length body) 3) (id= (2nd body) :if))
+             (setf condition (3rd body) body (list (1st body))))
+      typestr (check-keyword-with-arrow kw '(:do :yield) 'error)
+      (if (and (cddr body) (not (id= kw :do)))
+        (error "Multiple forms following a ~A keyword" kw))
+      (push 'progn body)
+      (if typestr
+        (with-gensym collect
+          (if (string= "" typestr)
+            (return `(let ( (type (type-of1 ,thing)) (collect ',collect)
+                            (var ',var) (thing ',thing)
+                            (condition ',condition) (body ',body) )
+                       (eval `(with-type-collector ,type ,collect
+                                (iterdo ,var ,thing
+                                  (if ,condition (,collect ,body)))))))
+            (let ( (type (read-from-string typestr)) )
+              (return `(with-type-collector ,type ,collect
+                         (iterdo ,var ,thing
+                           (if ,condition (,collect ,body)))))))))
+      (if (id= kw :yield)
+        (return `(yield ,body for ,var in ,thing if ,condition)))
+      `(iterdo ,var ,thing (if ,condition ,body))))
+
 (defmacro collect (expr for var in iter &optional if condition)
   (check-keyword for :for 'error)
   (check-keyword in :in 'error)

--- a/core/iterators.lisp
+++ b/core/iterators.lisp
@@ -80,9 +80,9 @@
         (slice s 2)
         (check-keyword kw (cat expected arrows) function))))
 
-;;; FOR with an arrow
-(defmacro forw (var in thing &body body)
-  (check-keyword in :in)
+;;; FOR with an arrow with alternative parameter order
+(defmacro over (thing as var &body body)
+  (check-keyword as :as)
   (bb kw (1st body)
       (if (consp kw) (setf kw :do) (pop body))
       (check-keyword-with-arrow kw '(:do :if :yield) 'error)

--- a/core/iterators.lisp
+++ b/core/iterators.lisp
@@ -52,13 +52,13 @@
   (check-keyword in :in)
   (bb kw (1st body)
       (if (consp kw) (setf kw :do) (pop body))
-      (check-keyword kw '(:do :if :collect :vcollect :yield) 'error)
+      (check-keyword kw '(:do :if :collect :vcollect :scollect :yield) 'error)
       condition t
       (mcond (id= kw :if)
              (setf condition (1st body) kw (2nd body) body (rrst body))
              (and (= (length body) 3) (id= (2nd body) :if))
              (setf condition (3rd body) body (list (1st body))))
-      (check-keyword kw '(:do :collect :vcollect :yield) 'error)
+      (check-keyword kw '(:do :collect :vcollect :scollect :yield) 'error)
       (if (and (cddr body) (not (id= kw :do)))
         (error "Multiple forms following a ~A keyword" kw))
       (push 'progn body)
@@ -71,6 +71,9 @@
                        (iterdo ,var ,thing (if ,condition (,collect ,body))))))
         (:vcollect (with-gensym collect
                      `(with-vcollector ,collect
+                        (iterdo ,var ,thing (if ,condition (,collect ,body))))))
+        (:scollect (with-gensym collect
+                     `(with-scollector ,collect
                         (iterdo ,var ,thing (if ,condition (,collect ,body)))))))))
 
 (defmacro collect (expr for var in iter &optional if condition)
@@ -87,6 +90,12 @@
     `(for ,var in ,iter vcollect ,expr ,if ,condition)
     `(for ,var in ,iter vcollect ,expr)))
 
+(defmacro scollect (expr for var in iter &optional if condition)
+  (check-keyword for :for 'error)
+  (check-keyword in :in 'error)
+  (if if
+    `(for ,var in ,iter scollect ,expr ,if ,condition)
+    `(for ,var in ,iter scollect ,expr)))
 
 (define-method (iterator (l list)) (fn () (if l (pop l) (iterend))))
 

--- a/core/iterators.lisp
+++ b/core/iterators.lisp
@@ -200,10 +200,6 @@
   (with-vcollector collect
     (for item in iterator do (collect item))))
 
-(defun sforce (iterator)
-  (with-scollector collect
-    (for item in iterator do (collect item))))
-
 (defun strforce (iterator)
   (with-char-collector collect
     (for item in iterator do (collect item))))


### PR DESCRIPTION
Suggested in #3 

I took the liberty of renaming `sforce` (for string) into `strforce` even though you didn't affirm it. By the way, it's interesting that in binding-block you indent body on par with parameters unlike in let.

EDIT:
I think the reason why I slightly prefer s- for sets and str- for string may be that a set of things seems more natural than a string of things, making set feel more fundamental than string.